### PR TITLE
Fixed login wrong username label

### DIFF
--- a/src/components/login.js
+++ b/src/components/login.js
@@ -169,9 +169,9 @@ class LoginForm extends PureComponent {
 									Uname:
 								</InputGroup.Addon>
 								<input type="text"
-											 placeholder="uname"
+											 placeholder="Username"
 											 className="form-control"
-											 value={this.state.uname}
+											 value={this.state.username}
 											 ref={(input) => { this.firstInput = input; }}
 											 onChange={(event) => this.onUnameChange(event)}
 								/>

--- a/src/components/login.js
+++ b/src/components/login.js
@@ -166,7 +166,7 @@ class LoginForm extends PureComponent {
 						<FormGroup className={unameError ? 'has-error' : ''}>
 							<InputGroup>
 								<InputGroup.Addon>
-									Uname:
+									Username:
 								</InputGroup.Addon>
 								<input type="text"
 											 placeholder="Username"

--- a/src/components/login.js
+++ b/src/components/login.js
@@ -171,7 +171,7 @@ class LoginForm extends PureComponent {
 								<input type="text"
 											 placeholder="Username"
 											 className="form-control"
-											 value={this.state.username}
+											 value={this.state.uname}
 											 ref={(input) => { this.firstInput = input; }}
 											 onChange={(event) => this.onUnameChange(event)}
 								/>


### PR DESCRIPTION
https://gyazo.com/5d4df37b732aeed846dd4bd653becba9

uname isn't UX friendly. Changed to username as label and placeholder value.